### PR TITLE
linux-renesas: add support for starting the CR7 from linux

### DIFF
--- a/recipes-kernel/linux/linux-renesas/rcar-rproc.patch
+++ b/recipes-kernel/linux/linux-renesas/rcar-rproc.patch
@@ -1997,3 +1997,273 @@ index b07354da223d..dc5fd00d0535 100644
 -- 
 2.28.0
 
+From 8bdb6841fbd2bc6047ceaa0ee234405ba5a85fb3 Mon Sep 17 00:00:00 2001
+From: Julien Massot <julien.massot@iot.bzh>
+Date: Thu, 3 Dec 2020 17:37:27 +0100
+Subject: [PATCH 1/2] soc: renesas: rcar-rst: Add support for Cortex R7
+
+Allow to set a boot address for the Cortex R7 processor.
+
+Signed-off-by: Julien Massot <julien.massot@iot.bzh>
+---
+ drivers/soc/renesas/rcar-rst.c       | 23 ++++++++++++++++++++++-
+ include/linux/soc/renesas/rcar-rst.h |  2 ++
+ 2 files changed, 24 insertions(+), 1 deletion(-)
+
+diff --git a/drivers/soc/renesas/rcar-rst.c b/drivers/soc/renesas/rcar-rst.c
+index d183c381e8db..32c2edb200ac 100644
+--- a/drivers/soc/renesas/rcar-rst.c
++++ b/drivers/soc/renesas/rcar-rst.c
+@@ -12,6 +12,8 @@
+ 
+ #define WDTRSTCR_RESET		0xA55A0002
+ #define WDTRSTCR		0x0054
++#define CR7BAR                  0x0070
++#define CR7BAREN                BIT(4)
+ 
+ static int rcar_rst_enable_wdt_reset(void __iomem *base)
+ {
+@@ -66,7 +68,7 @@ static const struct of_device_id rcar_rst_matches[] __initconst = {
+ 	{ /* sentinel */ }
+ };
+ 
+-static void __iomem *rcar_rst_base __initdata;
++static void __iomem *rcar_rst_base;
+ static u32 saved_mode __initdata;
+ 
+ static int __init rcar_rst_init(void)
+@@ -120,3 +122,22 @@ int __init rcar_rst_read_mode_pins(u32 *mode)
+ 	*mode = saved_mode;
+ 	return 0;
+ }
++
++int rcar_rst_set_rproc_boot_addr(u32 boot_addr)
++{
++	if (!rcar_rst_base) {
++			return -EIO;
++	}
++
++	if (boot_addr % SZ_4K) {
++		pr_debug("Invalid boot address for remote processor,"
++		       "should be aligned on 4k got %x\n", boot_addr);
++		pr_debug("rounding down to 4k\n");
++		boot_addr -= boot_addr % SZ_4K;
++	}
++
++	boot_addr |= CR7BAREN;
++	iowrite32(boot_addr, rcar_rst_base + CR7BAR);
++
++	return 0;
++}
+diff --git a/include/linux/soc/renesas/rcar-rst.h b/include/linux/soc/renesas/rcar-rst.h
+index 7899a5b8c247..7c97c2c4bba6 100644
+--- a/include/linux/soc/renesas/rcar-rst.h
++++ b/include/linux/soc/renesas/rcar-rst.h
+@@ -4,8 +4,10 @@
+ 
+ #ifdef CONFIG_RST_RCAR
+ int rcar_rst_read_mode_pins(u32 *mode);
++int rcar_rst_set_rproc_boot_addr(u32 boot_addr);
+ #else
+ static inline int rcar_rst_read_mode_pins(u32 *mode) { return -ENODEV; }
++static inline int rcar_rst_set_rproc_boot_addr(u32 boot_addr) { return -ENODEV; }
+ #endif
+ 
+ #endif /* __LINUX_SOC_RENESAS_RCAR_RST_H__ */
+-- 
+2.29.2
+
+From 425c05a232824b2e50f7a3660c57750ebfb12cf7 Mon Sep 17 00:00:00 2001
+From: Julien Massot <julien.massot@iot.bzh>
+Date: Tue, 8 Dec 2020 10:34:51 +0100
+Subject: [PATCH 2/2] remoteproc: rcar_rproc: add support for starting the
+ rproc
+
+In previous version this driver was only able to attach to an
+already started remoteproc.
+
+Starting the embbedded Cortex-r7 boils down to 4 steps:
+- powering up the remote processor
+- loading the firmware
+- setting cr7 boot address (CR7BAR)
+- deassert the reset line
+
+Signed-off-by: Julien Massot <julien.massot@iot.bzh>
+---
+ drivers/remoteproc/rcar_rproc.c | 111 ++++++++++++++++++++++++++++----
+ 1 file changed, 98 insertions(+), 13 deletions(-)
+
+diff --git a/drivers/remoteproc/rcar_rproc.c b/drivers/remoteproc/rcar_rproc.c
+index fb71aaf525f3..c2f71ae79e56 100644
+--- a/drivers/remoteproc/rcar_rproc.c
++++ b/drivers/remoteproc/rcar_rproc.c
+@@ -1,10 +1,14 @@
++#include <linux/limits.h>
+ #include <linux/mailbox_client.h>
+ #include <linux/mfd/syscon.h>
+ #include <linux/module.h>
+ #include <linux/of_device.h>
+ #include <linux/of_reserved_mem.h>
++#include <linux/pm_runtime.h>
+ #include <linux/regmap.h>
+ #include <linux/remoteproc.h>
++#include <linux/reset.h>
++#include <linux/soc/renesas/rcar-rst.h>
+ #include <linux/workqueue.h>
+ 
+ #include "remoteproc_internal.h"
+@@ -25,6 +29,7 @@ struct rcar_rproc {
+ 	struct mbox_client              cl;
+ 	struct mbox_chan		*tx_ch;
+ 	struct mbox_chan		*rx_ch;
++	struct reset_control            *rst;
+ 	struct workqueue_struct         *workqueue;
+ 	struct work_struct              vq_work;
+ 	struct rcar_syscon              rsctbl;
+@@ -127,10 +132,44 @@ static int rcar_rproc_attach(struct rproc *rproc)
+ 	return 0;
+ }
+ 
+-static struct rproc_ops rcar_rproc_ops = {
+-	.attach		= rcar_rproc_attach,
+-	.kick		= rcar_rproc_kick,
+-};
++static int rcar_rproc_start(struct rproc *rproc)
++{
++	struct rcar_rproc *priv = rproc->priv;
++	int err;
++
++	if (!rproc->bootaddr)
++		return -EINVAL;
++
++	/* RCar remote proc only support boot address on 32 bits */
++	if (rproc->bootaddr > U32_MAX)
++		return -EINVAL;
++
++	err = rcar_rst_set_rproc_boot_addr((u32)rproc->bootaddr);
++	if (err) {
++		dev_err(&rproc->dev, "failed to set rproc boot addr\n");
++		return err;
++	}
++
++	err = reset_control_deassert(priv->rst);
++	if (err) {
++		dev_err(&rproc->dev, "failed to bring out of reset\n");
++	}
++
++	return err;
++}
++
++static int rcar_rproc_stop(struct rproc *rproc)
++{
++	struct rcar_rproc *priv = rproc->priv;
++	int err;
++
++	err = reset_control_assert(priv->rst);
++	if (err) {
++		dev_err(&rproc->dev, "failed to put in reset\n");
++	}
++
++	return err;
++}
+ 
+ static int rcar_rproc_pa_to_da(struct rproc *rproc, phys_addr_t pa, u64 *da)
+ {
+@@ -215,6 +254,38 @@ static int rcar_rproc_parse_memory_regions(struct rproc *rproc)
+ 	return 0;
+ };
+ 
++static int rcar_rproc_elf_load_rsc_table(struct rproc *rproc,
++					  const struct firmware *fw)
++{
++	if (rproc_elf_load_rsc_table(rproc, fw))
++		dev_info(&rproc->dev, "no resource table found for this firmware\n");
++
++	return 0;
++}
++
++static int rcar_rproc_parse_fw(struct rproc *rproc, const struct firmware *fw)
++{
++	int ret = rcar_rproc_parse_memory_regions(rproc);
++
++	if (ret)
++		return ret;
++
++	return rcar_rproc_elf_load_rsc_table(rproc, fw);
++}
++
++static struct rproc_ops rcar_rproc_ops = {
++	.start		= rcar_rproc_start,
++	.stop		= rcar_rproc_stop,
++	.attach		= rcar_rproc_attach,
++	.kick		= rcar_rproc_kick,
++	.load		= rproc_elf_load_segments,
++	.parse_fw	= rcar_rproc_parse_fw,
++	.find_loaded_rsc_table = rproc_elf_find_loaded_rsc_table,
++	.sanity_check	= rproc_elf_sanity_check,
++	.get_boot_addr	= rproc_elf_get_boot_addr,
++
++};
++
+ static int rcar_rproc_get_syscon(struct device_node *np, const char *prop,
+ 				  struct rcar_syscon *syscon)
+ {
+@@ -310,18 +381,30 @@ static int rcar_rproc_probe(struct platform_device *pdev)
+ 	priv->rproc = rproc;
+ 	priv->dev = dev;
+ 
+-	dev_set_drvdata(dev, rproc);
+-
+-	ret = rcar_rproc_get_loaded_rsc_table(pdev, rproc, priv);
+-	if (ret)
++	priv->rst = devm_reset_control_get_exclusive(&pdev->dev, NULL);
++	if (IS_ERR(priv->rst)) {
++		ret = PTR_ERR(priv->rst);
++		dev_err(dev, "failed to get rproc reset\n");
+ 		goto free_rproc;
++	}
+ 
+-	ret = rcar_rproc_parse_memory_regions(rproc);
+-	if (ret)
+-		goto free_rproc;
++	pm_runtime_enable(priv->dev);
++
++	dev_set_drvdata(dev, rproc);
+ 
+-	/* Assume rproc is loaded by another component e.g u-boot */
+-	rproc->state = RPROC_DETACHED;
++	ret = rcar_rproc_get_loaded_rsc_table(pdev, rproc, priv);
++	if (!ret) {
++		rproc->state = RPROC_DETACHED;
++		ret = rcar_rproc_parse_memory_regions(rproc);
++		if (ret)
++			goto free_rproc;
++	} else {
++		ret = pm_runtime_get_sync(priv->dev);
++		if (ret) {
++			dev_err(&rproc->dev, "failed to power up\n");
++			goto free_rproc;
++		}
++	}
+ 
+ 	priv->workqueue = create_workqueue(dev_name(dev));
+ 	if (!priv->workqueue) {
+@@ -348,6 +431,7 @@ static int rcar_rproc_probe(struct platform_device *pdev)
+ 	destroy_workqueue(priv->workqueue);
+ free_resources:
+ 	rproc_resource_cleanup(rproc);
++	pm_runtime_disable(priv->dev);
+ free_rproc:
+ 	rproc_free(rproc);
+ 
+@@ -362,6 +446,7 @@ static int rcar_rproc_remove(struct platform_device *pdev)
+ 	rproc_del(rproc);
+ 	rcar_rproc_free_mbox(rproc);
+ 	destroy_workqueue(priv->workqueue);
++	pm_runtime_disable(priv->dev);
+ 	if (priv->rsc_va)
+ 		iounmap(priv->rsc_va);
+ 	rproc_free(rproc);
+-- 
+2.29.2
+


### PR DESCRIPTION
Put your firmware in /lib/firmware and then

$ echo stop >/sys/class/remoteproc/remoteproc0/state
$ echo -n zephyr.elf >/sys/class/remoteproc/remoteproc0/firmware
$ echo start >/sys/class/remoteproc/remoteproc0/state