### PR TITLE
linux-renesas: fixup to build rcar_rproc as a module

### DIFF
--- a/recipes-kernel/linux/linux-renesas/rcar-rproc.patch
+++ b/recipes-kernel/linux/linux-renesas/rcar-rproc.patch
@@ -2288,3 +2288,34 @@ index 32c2edb200ac..f6b98a521c87 100644
 -- 
 2.29.2
 
+From 80eb49f52b6313319cf65865707e990adb3c2c36 Mon Sep 17 00:00:00 2001
+From: Julien Massot <julien.massot@iot.bzh>
+Date: Tue, 15 Dec 2020 11:43:03 +0100
+Subject: [PATCH] remoteproc: rcar: disable auto_boot
+
+Since remoteproc try to fetch a firmware before filesytem is there,
+the request hang for few second a delay the possibility to request a
+start manually.
+
+Let the user the choice to start the remote processor.
+---
+ drivers/remoteproc/rcar_rproc.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/remoteproc/rcar_rproc.c b/drivers/remoteproc/rcar_rproc.c
+index 54634f4f1481..4d745278049e 100644
+--- a/drivers/remoteproc/rcar_rproc.c
++++ b/drivers/remoteproc/rcar_rproc.c
+@@ -403,6 +403,9 @@ static int rcar_rproc_probe(struct platform_device *pdev)
+ 		ret = rcar_rproc_parse_memory_regions(rproc);
+ 		if (ret)
+ 			goto free_rproc;
++	} else {
++		/* Manually start the rproc */
++		rproc->auto_boot = false;
+ 	}
+ 
+ 	priv->workqueue = create_workqueue(dev_name(dev));
+-- 
+2.29.2
+


### PR DESCRIPTION
In previous patch rcar_rst_set_rproc_boot_addr symbol was not
exported, and prevents rcar_rproc to be buils as a module.